### PR TITLE
test: add test in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+# (base: https://rustwasm.github.io/wasm-bindgen/wasm-bindgen-test/continuous-integration.html#github-actions)
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - run: wasm-pack test --headless --chrome
+      - run: wasm-pack test --node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,5 +11,6 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
+      - run: cargo build --tests
       - run: wasm-pack test --headless --chrome
       - run: wasm-pack test --node

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ target = "wasm32-unknown-unknown"
 js-sys = "^0.3.40"
 web-sys = "0.3"
 wasm-bindgen = "0.2.67"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.13"

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,9 @@
+use wasm_console;
+
+pub fn test_console() {
+    wasm_console::log!("console.log():", true, 1.3);
+    wasm_console::debug!("console.debug():", true, 1.3);
+    wasm_console::info!("console.info():", true, 1.3);
+    wasm_console::warn!("console.warn():", true, 1.3);
+    wasm_console::error!("console.error():", true, 1.3);
+}

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -1,0 +1,10 @@
+#![cfg(target_arch = "wasm32")]
+
+use wasm_bindgen_test;
+use wasm_bindgen_test::*;
+mod common;
+
+#[wasm_bindgen_test]
+fn test_console() {
+    common::test_console();
+}

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -1,0 +1,12 @@
+#![cfg(target_arch = "wasm32")]
+
+use wasm_bindgen_test;
+use wasm_bindgen_test::*;
+mod common;
+
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn test_console() {
+    common::test_console();
+}

--- a/webdriver.json
+++ b/webdriver.json
@@ -1,0 +1,5 @@
+{
+  "goog:chromeOptions": {
+    "args": []
+  }
+}


### PR DESCRIPTION
Run `wasm_console::log()`, `::info()` and so on run on GitHub Actions.

<img width="531" alt="image" src="https://user-images.githubusercontent.com/10933561/89724554-79d4b780-da3f-11ea-87a2-7faa36232479.png">
<img width="503" alt="image" src="https://user-images.githubusercontent.com/10933561/89724556-80fbc580-da3f-11ea-932c-ff991f4a4343.png">

https://github.com/nwtgck/wasm-console/runs/962926632?check_suite_focus=true